### PR TITLE
use the lowercase of the node name

### DIFF
--- a/src/dom-to-react/index.js
+++ b/src/dom-to-react/index.js
@@ -67,7 +67,7 @@ class Dom2React {
     switch (node.nodeType) {
       case 1: // regular dom-node
         return React.createElement(
-          node.nodeName,
+          node.nodeName.toLowerCase(),
           this.prepareAttributes(node, key),
           this.prepareChildren(node.childNodes, level)
         );


### PR DESCRIPTION
since react doesn't like uppercase node names (lots of warning in the console, despite it being mostly harmless atm).